### PR TITLE
Fix mobile positioning of controls toggle button

### DIFF
--- a/src/js/Ui.js
+++ b/src/js/Ui.js
@@ -212,7 +212,7 @@ var Ui = ( function() {
             // e.g., { 0: { src: 'blob_url_kick', gain: 0.9 } }
             var samplesToLoad = {};
             samplesToLoad[sampleIndex] = sampleData;
-            
+
             Sequencer.loadCustomSamples(samplesToLoad);
             Sequencer.initSampler(); // Immediately rebuild and activate the sampler
 

--- a/src/js/sequencer.js
+++ b/src/js/sequencer.js
@@ -251,7 +251,7 @@ var Sequencer = ( function() {
 
     var loadCustomSamples = function( newSampleData ) {
         Debug.log( 'Sequencer.loadCustomSamples()', newSampleData );
-        
+
         var sampleIndex = Object.keys(newSampleData)[0];
         var sampleData = newSampleData[sampleIndex];
 

--- a/src/js/timeline.js
+++ b/src/js/timeline.js
@@ -62,7 +62,7 @@ var Timeline = ( function() {
                         // Avoid logging the whole 'data' object if it's complex or causes issues
                         Debug.log('Timeline: sequencer/addSequenceItem event. Step: ' + (data ? String(data.step) : 'N/A') + ', Sample: ' + (data ? String(data.sample) : 'N/A'));
                     }
-                    
+
                     // wait for all SVGs to load before adding notes
                     var waiter = setInterval( function() {
                         // It's good practice to also wrap setInterval's callback content if it can fail

--- a/src/less/ui--controls.less
+++ b/src/less/ui--controls.less
@@ -105,6 +105,16 @@
 	.control-button--narrow {
 		width: auto;
 	}
+
+	// ===== START NEW CSS FIX =====
+	.ui-toggle--controls {
+		top: 0.5rem;      // Adjust to align with parent's padding-top (0.5rem on .ui--controls)
+		right: 0.5rem;    // Adjust to align with parent's padding-right (0.5rem on .ui--controls)
+		margin-top: 0;    // Remove the negative top margin
+		// Optionally, ensure it's above other elements if necessary, though likely not an issue here.
+		// z-index: 10;
+	}
+	// ===== END NEW CSS FIX =====
 }
 
 


### PR DESCRIPTION
This commit addresses an issue where the '.ui-toggle--controls' button (labeled "ctrl") was not correctly positioned or potentially interactive on mobile devices.

The problem was caused by `position: absolute` combined with a negative `margin-top` which behaved unpredictably on smaller screen sizes due to variations in font sizes and parent container dimensions.

The fix involves:
- Modifying `src/less/ui--controls.less`.
- Within the `@media screen and (max-width: 764px)` media query, the styles for `.ui-toggle--controls` have been updated to:
    - `top: 0.5rem;`
    - `right: 0.5rem;`
    - `margin-top: 0;` This ensures the button is reliably positioned in the top-right corner of the `.ui--controls` panel's padded area on mobile screens, making it visible and interactive.

I confirmed in a simulated mobile environment that this fixed the issue.